### PR TITLE
Fixed errors in build

### DIFF
--- a/example/simplekernel.cl
+++ b/example/simplekernel.cl
@@ -1,4 +1,5 @@
-__kernel void simplekernel(	__global int* input
+__kernel void simplekernel( __global int* input
+                          , __global int* output
                           , const int singlevalue )
 {
 	int i = get_global_id(0);

--- a/include/boundvalue.h
+++ b/include/boundvalue.h
@@ -1,7 +1,11 @@
 #ifndef _BOUNDVALUE_
 #define _BOUNDVALUE_
 
-#include <CL/cl.h>
+#ifdef __APPLE__
+  #include <OpenCL/cl.h>
+#else
+  #include <CL/cl.h>
+#endif
 
 enum BoundValueType { CL_MEM, SCALAR };
 

--- a/include/easyopencl.h
+++ b/include/easyopencl.h
@@ -1,7 +1,14 @@
 #ifndef _EASYOPENCL_
 #define _EASYOPENCL_
 
-#include <CL/cl.h>
+#ifdef __APPLE__
+  #include <OpenCL/cl.h>
+  #define clCreateCommandQueueWithProperties clCreateCommandQueue
+#else
+  #include <CL/cl.h>
+#endif
+
+typedef unsigned int uint;
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Added the missing parameter in the `simplekernel.cl` example to fix "use of undeclared identifier 'output'" error.

Added OS X specific ifdefs as `CL.h` is in OpenCL.

I added a typedef for `uint` as it isn't part of the c++ standard and wasn't being included from anywhere.
